### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,48 +6,48 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-MMA_7455				KEYWORD1
-MODE					KEYWORD1
-LEVEL_MODE				KEYWORD1
-TH_MODE					KEYWORD1
-PULSE_MODE				KEYWORD1
-ISR_MODE				KEYWORD1
-MMA7455_PROTOCOL		KEYWORD1
+MMA_7455	KEYWORD1
+MODE	KEYWORD1
+LEVEL_MODE	KEYWORD1
+TH_MODE	KEYWORD1
+PULSE_MODE	KEYWORD1
+ISR_MODE	KEYWORD1
+MMA7455_PROTOCOL	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin					KEYWORD2
-setChipSelectPin		KEYWORD2
-setSensitivity			KEYWORD2
-getSensitivity			KEYWORD2
-setMode					KEYWORD2
-getMode					KEYWORD2
-setSelfTest				KEYWORD2
-enableDetectionXYZ		KEYWORD2
-setThresholdMode		KEYWORD2
-setLevelPolarity		KEYWORD2
+begin	KEYWORD2
+setChipSelectPin	KEYWORD2
+setSensitivity	KEYWORD2
+getSensitivity	KEYWORD2
+setMode	KEYWORD2
+getMode	KEYWORD2
+setSelfTest	KEYWORD2
+enableDetectionXYZ	KEYWORD2
+setThresholdMode	KEYWORD2
+setLevelPolarity	KEYWORD2
 setLevelThresholdLimit	KEYWORD2
-setPulsePolarity		KEYWORD2
+setPulsePolarity	KEYWORD2
 setPulseThresholdLimit	KEYWORD2
-setPulseDuration		KEYWORD2
-setPulseLatency			KEYWORD2
-setPulseDuration2		KEYWORD2
-setAxisOffset			KEYWORD2
-getAxisOffset			KEYWORD2
-setInterruptMode		KEYWORD2
-getLevelDetection		KEYWORD2
-getPulseDetection		KEYWORD2
-getInterrupt			KEYWORD2
-clearInterrupt			KEYWORD2
-enableInterruptPins		KEYWORD2
-readAxis8				KEYWORD2
-readAxis8g				KEYWORD2
-readAxis10				KEYWORD2
-readAxis10g				KEYWORD2
-readReg					KEYWORD2
-writeReg				KEYWORD2
+setPulseDuration	KEYWORD2
+setPulseLatency	KEYWORD2
+setPulseDuration2	KEYWORD2
+setAxisOffset	KEYWORD2
+getAxisOffset	KEYWORD2
+setInterruptMode	KEYWORD2
+getLevelDetection	KEYWORD2
+getPulseDetection	KEYWORD2
+getInterrupt	KEYWORD2
+clearInterrupt	KEYWORD2
+enableInterruptPins	KEYWORD2
+readAxis8	KEYWORD2
+readAxis8g	KEYWORD2
+readAxis10	KEYWORD2
+readAxis10g	KEYWORD2
+readReg	KEYWORD2
+writeReg	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords